### PR TITLE
[API] Add 403s for non-fullnode indexed endpoints

### DIFF
--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -9,13 +9,17 @@
 // Contextual pointers provided by the index.js process
 let ptrTOKENS;
 let ptrRpcMain;
+let ptrIsFullnode;
 
 function init(context) {
     ptrTOKENS = context.TOKENS;
     ptrRpcMain = context.rpcMain;
+    ptrIsFullnode = context.isFullnode;
 }
 
 function getActivity(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.contract || req.params.contract.length <= 1) {
         return res.json({
             'error': "You must specify a 'contract' param!"
@@ -42,6 +46,8 @@ function getActivity(req, res) {
 }
 
 function getAllActivity(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.account || req.params.account.length <= 1) {
         return res.json({
             'error': "You must specify an 'account' param!"
@@ -52,6 +58,8 @@ function getAllActivity(req, res) {
 }
 
 function getBlockActivity(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.block || req.params.block.length <= 1) {
         return res.json({
             'error': "You must specify a 'block' param!"
@@ -87,6 +95,8 @@ function getBlockActivity(req, res) {
 }
 
 function getActivityByTxid(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.txid || req.params.txid.length !== 64) {
         return res.json({
             'error': "You must specify a valid 'txid' param!"
@@ -137,6 +147,8 @@ function getActivityByTxid(req, res) {
 }
 
 async function listDeltas(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -150,6 +162,13 @@ async function listDeltas(req, res) {
         console.error(e);
         return res.status(400).send('Internal API Error');
     }
+}
+
+function fullnodeError(res) {
+    return res.status(403).json({
+        'error': 'This endpoint is only available to Full-nodes, please ' +
+                 'connect an SCC Core RPC server to enable as a Full-node!'
+    });
 }
 
 exports.init = init;

--- a/src/api/blockchain.controller.js
+++ b/src/api/blockchain.controller.js
@@ -8,13 +8,24 @@
 
 // Contextual pointers provided by the index.js process
 let ptrGetFullMempool;
+let ptrIsFullnode;
 
 function init(context) {
     ptrGetFullMempool = context.gfm;
+    ptrIsFullnode = context.isFullnode;
 }
 
 async function getFullMempool(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     res.json(await ptrGetFullMempool());
+}
+
+function fullnodeError(res) {
+    return res.status(403).json({
+        'error': 'This endpoint is only available to Full-nodes, please ' +
+                 'connect an SCC Core RPC server to enable as a Full-node!'
+    });
 }
 
 exports.init = init;

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -8,16 +8,22 @@
 
 // Contextual pointers provided by the index.js process
 let ptrTOKENS;
+let ptrIsFullnode;
 
 function init(context) {
     ptrTOKENS = context.TOKENS;
+    ptrIsFullnode = context.isFullnode;
 }
 
 async function getAllTokens(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     res.json(ptrTOKENS.getTokensPtr());
 }
 
 function getToken(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.contract || req.params.contract.length !== 64) {
         return res.json({
             'error': "You must specify a 'contract' param!"
@@ -33,12 +39,21 @@ function getToken(req, res) {
 }
 
 function getTokensByAccount(req, res) {
+    if (!ptrIsFullnode())
+        return fullnodeError(res);
     if (!req.params.account || req.params.account.length <= 1) {
         return res.json({
             'error': "You must specify an 'account' param!"
         });
     }
     res.json(ptrTOKENS.getTokensByAccount(req.params.account));
+}
+
+function fullnodeError(res) {
+    return res.status(403).json({
+        'error': 'This endpoint is only available to Full-nodes, please ' +
+                 'connect an SCC Core RPC server to enable as a Full-node!'
+    });
 }
 
 exports.init = init;

--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -35,18 +35,25 @@ async function getStakingStatus(req, res) {
             'error': "You must specify an 'account' param!"
         });
     }
-    const cToken = ptrTOKENS.getToken(req.params.contract);
-    if (cToken.error) {
-        return res.json({
-            'error': 'Token contract does not exist!'
-        });
+    const isFullnode = ptrIsFullnode();
+    let cToken;
+    if (isFullnode) {
+        cToken = ptrTOKENS.getToken(req.params.contract);
+        if (cToken.error) {
+            return res.json({
+                'error': 'Token contract does not exist!'
+            });
+        }
+        if (cToken.version !== 2) {
+            return res.json({
+                'error': 'Token is not an SCP-2!'
+            });
+        }
     }
-    if (cToken.version !== 2) {
-        return res.json({
-            'error': 'Token is not an SCP-2!'
-        });
-    }
-    res.json(cToken.getStakingStatus(req.params.account));
+    res.json(isFullnode
+            ? cToken.getStakingStatus(req.params.account)
+            : JSON.parse(await ptrNET.getLightStakingStatus(req.params.contract,
+                                                 req.params.account)));
 }
 
 async function getBalances(req, res) {

--- a/src/index.js
+++ b/src/index.js
@@ -136,13 +136,16 @@ const app = express();
 // Setup and initialize API modules, providing mutable pointer contexts to all necessary states
 apiACTIVITY.init(app, {
     'TOKENS': TOKENS,
-    'rpcMain': rpcMain
+    'rpcMain': rpcMain,
+    'isFullnode': isFullnodePtr
 });
 apiBLOCKCHAIN.init(app, {
-    'gfm': getFullMempool
+    'gfm': getFullMempool,
+    'isFullnode': isFullnodePtr
 });
 apiTOKENS.init(app, {
-    'TOKENS': TOKENS
+    'TOKENS': TOKENS,
+    'isFullnode': isFullnodePtr
 });
 apiWALLET.init(app, {
     'TOKENS': TOKENS,

--- a/src/network.js
+++ b/src/network.js
@@ -85,6 +85,10 @@ async function getLightUTXOs(address) {
     return await get(rootSCCNet + 'getutxos?addr=' + address);
 }
 
+async function getLightStakingStatus(contract, address) {
+    return await get(rootSCCNet + 'scp/getstakingstatus/' + contract + '/' + address);
+}
+
 async function getMempoolLight() {
     return await get(rootSCCNet + 'scp/getrawmempool');
 }
@@ -106,6 +110,7 @@ exports.post = post;
 exports.getActivityLight = getActivityLight;
 exports.getDeltasLight = getDeltasLight;
 exports.getLightUTXOs = getLightUTXOs;
+exports.getLightStakingStatus = getLightStakingStatus;
 exports.getMempoolLight = getMempoolLight;
 exports.getLightTokensByAccount = getLightTokensByAccount;
 exports.broadcastTx = broadcastTx;


### PR DESCRIPTION
This will encourage users of the explorer-like indexed APIs to setup their own Full-nodes instead of relying too much on a fallback server, this also makes it more obvious which endpoints work on Full-nodes and which are allowed to use a Fallback server for.

Fallbacks are mostly recommended for basic wallet functions, useful for quick plug'n'play financial integrations.