### PR TITLE
[API] Add new API config options

### DIFF
--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -7,7 +7,7 @@
 'use strict';
 
 // The permissions controller, allows/disallows usage of the module
-let cPerms = require('./permissions.js');
+const cPerms = require('./permissions.js');
 
 // Contextual pointers provided by the index.js process
 let ptrTOKENS;
@@ -22,7 +22,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ DB: context.DB });
+    cPerms.init({ 'DB': context.DB });
 }
 
 function getActivity(req, res) {

--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -22,7 +22,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ 'DB': context.DB });
+    return cPerms.init({ 'DB': context.DB, 'strModule': strModule });
 }
 
 function getActivity(req, res) {

--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -6,18 +6,29 @@
 
 'use strict';
 
+// The permissions controller, allows/disallows usage of the module
+let cPerms = require('./permissions.js');
+
 // Contextual pointers provided by the index.js process
 let ptrTOKENS;
 let ptrRpcMain;
 let ptrIsFullnode;
+let strModule;
 
 function init(context) {
     ptrTOKENS = context.TOKENS;
     ptrRpcMain = context.rpcMain;
     ptrIsFullnode = context.isFullnode;
+    // Static Non-Pointer (native value)
+    strModule = context.strModule;
+    // Initialize permissions controller
+    cPerms.init({ DB: context.DB });
 }
 
 function getActivity(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -47,6 +58,9 @@ function getActivity(req, res) {
 }
 
 function getAllActivity(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -60,6 +74,9 @@ function getAllActivity(req, res) {
 }
 
 function getBlockActivity(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -98,6 +115,9 @@ function getBlockActivity(req, res) {
 }
 
 function getActivityByTxid(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -151,6 +171,9 @@ function getActivityByTxid(req, res) {
 }
 
 async function listDeltas(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -173,6 +196,12 @@ function fullnodeError(res) {
     return res.status(403).json({
         'error': 'This endpoint is only available to Full-nodes, please ' +
                  'connect an SCC Core RPC server to enable as a Full-node!'
+    });
+}
+
+function disabledError(res) {
+    return res.status(403).json({
+        'error': 'This module (' + strModule + ') is disabled!'
     });
 }
 

--- a/src/api/activity.routes.js
+++ b/src/api/activity.routes.js
@@ -9,9 +9,11 @@
 const cController = require('./activity.controller.js');
 
 // The main 'route' for this API module
-const strRoute = '/api/v1/activity/';
+const strModule = 'activity';
+const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
+    context.strModule = strModule;
     cController.init(context);
 
     // Get a single account's activity/history for a single token

--- a/src/api/activity.routes.js
+++ b/src/api/activity.routes.js
@@ -14,7 +14,7 @@ const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
     context.strModule = strModule;
-    cController.init(context);
+    const cbackRes = cController.init(context);
 
     // Get a single account's activity/history for a single token
     app.get(strRoute + 'getactivity/:contract/:account',
@@ -47,6 +47,9 @@ function init(app, context) {
         cController.getActivityByTxid);
     app.get('/api/v1/wallet/listdeltas/:address',
         cController.listDeltas);
+
+    // Return if this module is enabled via config
+    return cbackRes;
 }
 
 exports.init = init;

--- a/src/api/blockchain.controller.js
+++ b/src/api/blockchain.controller.js
@@ -20,7 +20,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ 'DB': context.DB });
+    return cPerms.init({ 'DB': context.DB, 'strModule': strModule });
 }
 
 async function getFullMempool(req, res) {

--- a/src/api/blockchain.controller.js
+++ b/src/api/blockchain.controller.js
@@ -7,7 +7,7 @@
 'use strict';
 
 // The permissions controller, allows/disallows usage of the module
-let cPerms = require('./permissions.js');
+const cPerms = require('./permissions.js');
 
 // Contextual pointers provided by the index.js process
 let ptrGetFullMempool;
@@ -20,7 +20,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ DB: context.DB });
+    cPerms.init({ 'DB': context.DB });
 }
 
 async function getFullMempool(req, res) {

--- a/src/api/blockchain.controller.js
+++ b/src/api/blockchain.controller.js
@@ -6,16 +6,27 @@
 
 'use strict';
 
+// The permissions controller, allows/disallows usage of the module
+let cPerms = require('./permissions.js');
+
 // Contextual pointers provided by the index.js process
 let ptrGetFullMempool;
 let ptrIsFullnode;
+let strModule;
 
 function init(context) {
     ptrGetFullMempool = context.gfm;
     ptrIsFullnode = context.isFullnode;
+    // Static Non-Pointer (native value)
+    strModule = context.strModule;
+    // Initialize permissions controller
+    cPerms.init({ DB: context.DB });
 }
 
 async function getFullMempool(req, res) {
+    if (!cPerms.isModuleAllowed(strModule)) {
+        return disabledError(res);
+    }
     if (!ptrIsFullnode()) {
         return fullnodeError(res);
     }
@@ -26,6 +37,12 @@ function fullnodeError(res) {
     return res.status(403).json({
         'error': 'This endpoint is only available to Full-nodes, please ' +
                  'connect an SCC Core RPC server to enable as a Full-node!'
+    });
+}
+
+function disabledError(res) {
+    return res.status(403).json({
+        'error': 'This module (' + strModule + ') is disabled!'
     });
 }
 

--- a/src/api/blockchain.routes.js
+++ b/src/api/blockchain.routes.js
@@ -9,9 +9,11 @@
 const cController = require('./blockchain.controller.js');
 
 // The main 'route' for this API module
-const strRoute = '/api/v1/blockchain/';
+const strModule = 'blockchain';
+const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
+    context.strModule = strModule;
     cController.init(context);
 
     // Get the current raw mempool

--- a/src/api/blockchain.routes.js
+++ b/src/api/blockchain.routes.js
@@ -1,7 +1,7 @@
 /*
-  # This Source Code Form is subject to the terms of the Mozilla Public
-  # License, v. 2.0. If a copy of the MPL was not distributed with this
-  # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+    # This Source Code Form is subject to the terms of the Mozilla Public
+    # License, v. 2.0. If a copy of the MPL was not distributed with this
+    # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 */
 
 'use strict';
@@ -14,7 +14,7 @@ const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
     context.strModule = strModule;
-    cController.init(context);
+    const cbackRes = cController.init(context);
 
     // Get the current raw mempool
     app.get(strRoute + 'getrawmempool',
@@ -23,6 +23,9 @@ function init(app, context) {
     /// / BACKWARDS-COMPAT: Removal scheduled for v1.1.6
     app.get('/api/v1/getrawmempool',
         cController.getFullMempool);
+
+    // Return if this module is enabled via config
+    return cbackRes;
 }
 
 exports.init = init;

--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -22,6 +22,8 @@ function init(context) {
             return a.trim();
         });
     }
+    // Return if this module is enabled/disabled
+    return isModuleAllowed(context.strModule);
 }
 
 // Return if an API module is enabled or disabled in the REST interface, via config cache

--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -1,0 +1,31 @@
+/*
+  # This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+'use strict';
+
+let ptrDB;
+
+// The cached API modules
+let arrConfModules = [];
+
+function init(context) {
+    ptrDB = context.DB;
+    // Load, parse and cache the API modules
+    let strConfModules = ptrDB.getConfigValue("apimodules", false, false);
+    if (strConfModules && strConfModules.length) {
+        // Convert to lowercase, splice into an array using commas as seperators, then trim all input
+        arrConfModules = strConfModules.toLowerCase().split(",");
+        arrConfModules = arrConfModules.map((a)=> { return a.trim() });
+    }
+}
+
+// Return if an API module is enabled or disabled in the REST interface, via config cache
+function isModuleAllowed(strModule) {
+    return arrConfModules.includes(strModule);
+}
+
+exports.init = init;
+exports.isModuleAllowed = isModuleAllowed;

--- a/src/api/permissions.js
+++ b/src/api/permissions.js
@@ -14,11 +14,13 @@ let arrConfModules = [];
 function init(context) {
     ptrDB = context.DB;
     // Load, parse and cache the API modules
-    let strConfModules = ptrDB.getConfigValue("apimodules", false, false);
+    const strConfModules = ptrDB.getConfigValue('apimodules', false, false);
     if (strConfModules && strConfModules.length) {
         // Convert to lowercase, splice into an array using commas as seperators, then trim all input
-        arrConfModules = strConfModules.toLowerCase().split(",");
-        arrConfModules = arrConfModules.map((a)=> { return a.trim() });
+        arrConfModules = strConfModules.toLowerCase().split(',');
+        arrConfModules = arrConfModules.map((a) => {
+            return a.trim();
+        });
     }
 }
 

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -20,7 +20,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ 'DB': context.DB });
+    return cPerms.init({ 'DB': context.DB, 'strModule': strModule });
 }
 
 async function getAllTokens(req, res) {

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -7,7 +7,7 @@
 'use strict';
 
 // The permissions controller, allows/disallows usage of the module
-let cPerms = require('./permissions.js');
+const cPerms = require('./permissions.js');
 
 // Contextual pointers provided by the index.js process
 let ptrTOKENS;
@@ -20,7 +20,7 @@ function init(context) {
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
-    cPerms.init({ DB: context.DB });
+    cPerms.init({ 'DB': context.DB });
 }
 
 async function getAllTokens(req, res) {

--- a/src/api/tokens.routes.js
+++ b/src/api/tokens.routes.js
@@ -14,7 +14,7 @@ const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
     context.strModule = strModule;
-    cController.init(context);
+    const cbackRes = cController.init(context);
 
     // Get All Tokens
     app.get(strRoute + 'getalltokens',
@@ -35,6 +35,9 @@ function init(app, context) {
         cController.getToken);
     app.get('/api/v1/gettokensbyaccount/:account',
         cController.getTokensByAccount);
+
+    // Return if this module is enabled via config
+    return cbackRes;
 }
 
 exports.init = init;

--- a/src/api/tokens.routes.js
+++ b/src/api/tokens.routes.js
@@ -9,9 +9,11 @@
 const cController = require('./tokens.controller.js');
 
 // The main 'route' for this API module
-const strRoute = '/api/v1/tokens/';
+const strModule = 'tokens';
+const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
+    context.strModule = strModule;
     cController.init(context);
 
     // Get All Tokens

--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -7,7 +7,7 @@
 'use strict';
 
 // The permissions controller, allows/disallows usage of the module
-let cPerms = require('./permissions.js');
+const cPerms = require('./permissions.js');
 
 // Contextual pointers provided by the index.js process
 let ptrWALLET;
@@ -28,7 +28,7 @@ function init(context) {
     strModule = context.strModule;
     COIN = context.COIN;
     // Initialize permissions controller
-    cPerms.init({ DB: context.DB });
+    cPerms.init({ 'DB': context.DB });
 }
 
 async function getStakingStatus(req, res) {

--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -28,7 +28,7 @@ function init(context) {
     strModule = context.strModule;
     COIN = context.COIN;
     // Initialize permissions controller
-    cPerms.init({ 'DB': context.DB });
+    return cPerms.init({ 'DB': context.DB, 'strModule': strModule });
 }
 
 async function getStakingStatus(req, res) {

--- a/src/api/wallet.routes.js
+++ b/src/api/wallet.routes.js
@@ -9,9 +9,11 @@
 const cController = require('./wallet.controller.js');
 
 // The main 'route' for this API module
-const strRoute = '/api/v1/wallet/';
+const strModule = 'wallet';
+const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
+    context.strModule = strModule;
     cController.init(context);
 
     // Get an SCP-2 token's staking status for a single account

--- a/src/api/wallet.routes.js
+++ b/src/api/wallet.routes.js
@@ -14,7 +14,7 @@ const strRoute = '/api/v1/' + strModule + '/';
 
 function init(app, context) {
     context.strModule = strModule;
-    cController.init(context);
+    const cbackRes = cController.init(context);
 
     // Get an SCP-2 token's staking status for a single account
     app.get(strRoute + 'getstakingstatus/:contract/:account',
@@ -38,6 +38,9 @@ function init(app, context) {
     /// / BACKWARDS-COMPAT: Removal scheduled for v1.1.6
     app.get('/api/v1/getstakingstatus/:contract/:account',
         cController.getStakingStatus);
+
+    // Return if this module is enabled via config
+    return cbackRes;
 }
 
 exports.init = init;

--- a/src/index.js
+++ b/src/index.js
@@ -126,6 +126,9 @@ const nFirstBlock = 155084;
 // The amount of satoshis that make a full coin
 const COIN = 100000000;
 
+// The default REST API port
+const nDefaultApiPort = 3000;
+
 // The SCP deployment fee, in SCC
 const nDeployFee = 10;
 const strDeployFeeDest = 'sccburnaddressXXXXXXXXXXXXXXSfqakF';
@@ -133,34 +136,42 @@ const strDeployFeeDest = 'sccburnaddressXXXXXXXXXXXXXXSfqakF';
 // Express Server
 const express = require('express');
 const app = express();
-// Setup and initialize API modules, providing mutable pointer contexts to all necessary states
-apiACTIVITY.init(app, {
-    'TOKENS': TOKENS,
-    'rpcMain': rpcMain,
-    'isFullnode': isFullnodePtr
-});
-apiBLOCKCHAIN.init(app, {
-    'gfm': getFullMempool,
-    'isFullnode': isFullnodePtr
-});
-apiTOKENS.init(app, {
-    'TOKENS': TOKENS,
-    'isFullnode': isFullnodePtr
-});
-apiWALLET.init(app, {
-    'TOKENS': TOKENS,
-    'WALLET': WALLET,
-    'NET': NET,
-    'DB': DB,
-    'isFullnode': isFullnodePtr,
-    'COIN': COIN
-});
-
-app.listen(3000);
 
 async function init(forcedCorePath = false) {
     // Initialize the DB, load configs into memory
     await DB.init(forcedCorePath);
+    // Initialize API modules, providing mutable pointer contexts to all necessary states
+    apiACTIVITY.init(app, {
+        'TOKENS': TOKENS,
+        'DB': DB,
+        'rpcMain': rpcMain,
+        'isFullnode': isFullnodePtr
+    });
+    apiBLOCKCHAIN.init(app, {
+        'gfm': getFullMempool,
+        'DB': DB,
+        'isFullnode': isFullnodePtr
+    });
+    apiTOKENS.init(app, {
+        'TOKENS': TOKENS,
+        'DB': DB,
+        'isFullnode': isFullnodePtr
+    });
+    apiWALLET.init(app, {
+        'TOKENS': TOKENS,
+        'WALLET': WALLET,
+        'NET': NET,
+        'DB': DB,
+        'isFullnode': isFullnodePtr,
+        'COIN': COIN
+    });
+    
+    // Load API port from config, use default if none exists, or fallback to default if the port is a non-int
+    let nApiPort = Number(DB.getConfigValue("apiport", nDefaultApiPort, false));
+    if (!Number.isSafeInteger(nApiPort)) nApiPort = nDefaultApiPort;
+    app.listen(nApiPort);
+    const strPortType = (nDefaultApiPort === nApiPort ? 'default' : 'custom');
+    console.log("API: Listening on " + strPortType + ' port! (' + nApiPort + ')');
     // Loop the StakeCubeCoin.conf file for RPC username and password params, if any
     try {
         // Load the wallet DB

--- a/src/index.js
+++ b/src/index.js
@@ -143,23 +143,24 @@ async function init(forcedCorePath = false) {
     await DB.init(forcedCorePath);
     // Initialize API modules, providing mutable pointer contexts to all necessary states
     if (!fApiInitialized) {
-        apiACTIVITY.init(app, {
+        const arrEnabledModules = [];
+        const fApiActivity = apiACTIVITY.init(app, {
             'TOKENS': TOKENS,
             'DB': DB,
             'rpcMain': rpcMain,
             'isFullnode': isFullnodePtr
         });
-        apiBLOCKCHAIN.init(app, {
+        const fApiBlockchain = apiBLOCKCHAIN.init(app, {
             'gfm': getFullMempool,
             'DB': DB,
             'isFullnode': isFullnodePtr
         });
-        apiTOKENS.init(app, {
+        const fApiTokens = apiTOKENS.init(app, {
             'TOKENS': TOKENS,
             'DB': DB,
             'isFullnode': isFullnodePtr
         });
-        apiWALLET.init(app, {
+        const fApiWallet = apiWALLET.init(app, {
             'TOKENS': TOKENS,
             'WALLET': WALLET,
             'NET': NET,
@@ -167,6 +168,10 @@ async function init(forcedCorePath = false) {
             'isFullnode': isFullnodePtr,
             'COIN': COIN
         });
+        if (fApiActivity) arrEnabledModules.push('activity');
+        if (fApiBlockchain) arrEnabledModules.push('blockchain');
+        if (fApiTokens) arrEnabledModules.push('tokens');
+        if (fApiWallet) arrEnabledModules.push('wallet');
 
         // Load API port from config, use default if none exists, or fallback to default if the port is a non-int
         let nApiPort = Number(DB.getConfigValue('apiport', nDefaultApiPort,
@@ -178,6 +183,14 @@ async function init(forcedCorePath = false) {
             : 'custom');
         console.log('API: Listening on ' + strPortType + ' port!' +
                     ' (' + nApiPort + ')');
+        // Log our module statuses
+        if (arrEnabledModules.length) {
+            console.log('API: ' + arrEnabledModules.length + ' modules ' +
+                        'enabled! (' + arrEnabledModules.join(', ') + ')');
+        } else {
+            console.log('API: Disabled! You can enable individual modules' +
+                        ' using "apimodules=mod1,mod2,..."');
+        }
         fApiInitialized = true;
     }
     // Loop the StakeCubeCoin.conf file for RPC username and password params, if any

--- a/src/network.js
+++ b/src/network.js
@@ -86,7 +86,8 @@ async function getLightUTXOs(address) {
 }
 
 async function getLightStakingStatus(contract, address) {
-    return await get(rootSCCNet + 'scp/getstakingstatus/' + contract + '/' + address);
+    return await get(rootSCCNet + 'scp/getstakingstatus/' + contract +
+                                                      '/' + address);
 }
 
 async function getMempoolLight() {


### PR DESCRIPTION
`apimodules` which has a comma-seperated list of API modules that are allowed to run, if the list is empty, then no modules are loaded, the options are, in any given order, style or quantity: `wallet, tokens, blockchain, activity`.
`apiport` which allows customizing the REST API port, from the default port 3000.

This PR also fixes issues with the GUI client failing to load the new API modules, and fixes conflicting Express server initializations.