### PR TITLE
[API] Improve controller module loading

### DIFF
--- a/src/api/activity.routes.js
+++ b/src/api/activity.routes.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const cController = require('./activity.controller.js');
-
 // The main 'route' for this API module
 const strModule = 'activity';
 const strRoute = '/api/v1/' + strModule + '/';
+
+const cController = require('./' + strModule + '.controller.js');
 
 function init(app, context) {
     context.strModule = strModule;

--- a/src/api/blockchain.routes.js
+++ b/src/api/blockchain.routes.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const cController = require('./blockchain.controller.js');
-
 // The main 'route' for this API module
 const strModule = 'blockchain';
 const strRoute = '/api/v1/' + strModule + '/';
+
+const cController = require('./' + strModule + '.controller.js');
 
 function init(app, context) {
     context.strModule = strModule;

--- a/src/api/io.routes.js
+++ b/src/api/io.routes.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const cController = require('./io.controller.js');
-
 // The main 'route' for this API module
 const strModule = 'io';
 const strRoute = '/api/v1/' + strModule + '/';
+
+const cController = require('./' + strModule + '.controller.js');
 
 function init(app, context) {
     context.strModule = strModule;

--- a/src/api/tokens.routes.js
+++ b/src/api/tokens.routes.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const cController = require('./tokens.controller.js');
-
 // The main 'route' for this API module
 const strModule = 'tokens';
 const strRoute = '/api/v1/' + strModule + '/';
+
+const cController = require('./' + strModule + '.controller.js');
 
 function init(app, context) {
     context.strModule = strModule;

--- a/src/api/wallet.routes.js
+++ b/src/api/wallet.routes.js
@@ -6,11 +6,11 @@
 
 'use strict';
 
-const cController = require('./wallet.controller.js');
-
 // The main 'route' for this API module
 const strModule = 'wallet';
 const strRoute = '/api/v1/' + strModule + '/';
+
+const cController = require('./' + strModule + '.controller.js');
 
 function init(app, context) {
     context.strModule = strModule;


### PR DESCRIPTION
This simple PR improves the API modules by auto-loading the controllers by their module name, instead of using hardcoded string paths.

This prevents developers from typos or mis-matches causing modules to fail, and also improves automation and modularization of the codebase. Yay!