### PR TITLE
[API] [IO] Move /write/ to binary POSTs

### DIFF
--- a/src/api/io.controller.js
+++ b/src/api/io.controller.js
@@ -65,20 +65,20 @@ async function writeTx(req, res) {
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
-    if (!req.params.data) {
-        return res.status(400).send('Missing "data" parameter!');
-    }
-    const strAddr = req.params.address;
-    const strData = req.params.data;
-    // Ensure the data doesn't exceed 500 bytes in HEX (the maximum SCC data relay)
-    const nByteLen = Buffer.from(strData).toString('hex').length;
-    if (nByteLen > 500) {
-        return res.status(400).json({
-            'error': 'The provided data (' + nByteLen + ' bytes in HEX) ' +
-                     'exceeds the maximum length of 500 bytes'
-        });
-    }
     try {
+        if (!req.body || !req.body.byteLength) {
+            return res.status(400).send('Missing "body" data!');
+        }
+        const strAddr = req.params.address;
+        const strData = req.body.toString();
+        // Ensure the data doesn't exceed 500 bytes in HEX (the maximum SCC data relay)
+        const nByteLen = req.body.byteLength * 2;
+        if (nByteLen > 500) {
+            return res.status(400).json({
+                'error': 'The provided data (' + nByteLen + ' bytes in HEX) ' +
+                         'exceeds the maximum length of 500 bytes'
+            });
+        }
         // Ensure we have the address specified, and it's unlocked
         const cWallet = ptrWALLET.getWallet(strAddr);
         if (!cWallet) {

--- a/src/api/io.routes.js
+++ b/src/api/io.routes.js
@@ -21,7 +21,7 @@ function init(app, context) {
         cController.readTx);
 
     // Write custom, retrievable data to the blockchain via an on-chain transaction
-    app.get(strRoute + 'write/:address/:data',
+    app.post(strRoute + 'write/:address',
         cController.writeTx);
 
     // Return if this module is enabled via config

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,7 @@ const strDeployFeeDest = 'sccburnaddressXXXXXXXXXXXXXXSfqakF';
 // Express Server
 const express = require('express');
 const app = express();
+app.use(express.raw({ type: () => { return true } }));
 let fInitialized = false;
 
 async function init(forcedCorePath = false, retry = false) {

--- a/src/index.js
+++ b/src/index.js
@@ -140,7 +140,11 @@ const strDeployFeeDest = 'sccburnaddressXXXXXXXXXXXXXXSfqakF';
 // Express Server
 const express = require('express');
 const app = express();
-app.use(express.raw({ type: () => { return true } }));
+app.use(express.raw({
+    'type': () => {
+        return true;
+    }
+}));
 let fInitialized = false;
 
 async function init(forcedCorePath = false, retry = false) {


### PR DESCRIPTION
The prior IO write system used GET with the 2nd URL parameter being the uploaded data, this caused problems since most encoders will refuse to submit raw data via a URL query, so I've shifted the system to use a POST body instead, with raw Byte Buffering, meaning ANY and ALL data types are accepted on the SCC Blockchain.

Files, text, binary, hex or any other encoded data is fully supported.

- The API is same as before, only the `/:data` param is removed from the URL, and is now using a POST body instead.