### PR TITLE
[SCP] [Consensus] SCP-2 Staking + Indexing Upgrade

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -462,7 +462,9 @@
         if (!cUTXO) return M.toast({html: 'You don\'t have enough SCC for gas fees!', displayLength: 3000});
         cTx.addinput(cUTXO.id, cUTXO.vout, cUTXO.script);
         // SCP output
-        cTx.addoutputburn(0.00000001, cToken.contract + " send " + (sendAmount * COIN).toFixed(0) + " " + sendAddress);
+        let fIndexed = UPGRADES.isTokenIndexingActive(isFullnodePtr() ? nCacheHeight : cachedBlockCount);
+        let idContract = fIndexed ? "id" + cToken.index : cToken.contract;
+        cTx.addoutputburn(0.00000001, idContract + " send " + (sendAmount * COIN).toFixed(0) + " " + sendAddress);
         // Fee & Change output
         let nFee = WALLET.getFee(cTx.serialize().length);
         let nChange = (parseFloat(cUTXO.sats / COIN) - parseFloat(nFee)).toFixed(8);
@@ -484,7 +486,9 @@
         if (!cUTXO) return M.toast({html: 'You don\'t have enough SCC for gas fees!', displayLength: 3000});
         cTx.addinput(cUTXO.id, cUTXO.vout, cUTXO.script);
         // SCP output
-        cTx.addoutputburn(0.00000001, cToken.contract + " redeem");
+        let fIndexed = UPGRADES.isTokenIndexingActive(isFullnodePtr() ? nCacheHeight : cachedBlockCount);
+        let idContract = fIndexed ? "id" + cToken.index : cToken.contract;
+        cTx.addoutputburn(0.00000001, idContract + " redeem");
         // Fee & Change output
         let nFee = WALLET.getFee(cTx.serialize().length);
         let nChange = (parseFloat(cUTXO.sats / COIN) - parseFloat(nFee)).toFixed(8);
@@ -521,7 +525,9 @@
           if (!cUTXO) return M.toast({html: 'You don\'t have enough SCC for gas fees!', displayLength: 3000});
           cTx.addinput(cUTXO.id, cUTXO.vout, cUTXO.script);
           // SCP output
-          cTx.addoutputburn(0.00000001, cToken.token.contract + " redeem");
+          let fIndexed = UPGRADES.isTokenIndexingActive(isFullnodePtr() ? nCacheHeight : cachedBlockCount);
+          let idContract = fIndexed ? "id" + cToken.token.index : cToken.token.contract;
+          cTx.addoutputburn(0.00000001, idContract + " redeem");
           // Fee & Change output
           let nFee = WALLET.getFee(cTx.serialize().length);
           let nChange = ((cUTXO.sats / COIN) - nFee).toFixed(8);
@@ -796,7 +802,7 @@
       }
 
       // Also use this to update the Claim All button's visibility
-      if (cachedTokens.length) {
+      if (cachedTokens.length && getSyncPercentage() >= 99.99) {
         let nPendingStakes = 0;
         for (const cToken of cachedTokens) {
           if (cToken.token.version !== 2) continue;

--- a/src/index.js
+++ b/src/index.js
@@ -456,9 +456,9 @@ async function getMsgFromTx(rawTX, strFormat = 'utf8') {
     }
     for (const cVout of res.vout) {
         if (!cVout.scriptPubKey) continue;
-        if (!cVout.scriptPubKey.asm) continue;
-        // Scan the scriptPubKey for OP_RETURN
-        if (cVout.scriptPubKey.asm.startsWith('OP_RETURN ')) {
+        if (!cVout.scriptPubKey.hex) continue;
+        // Scan the scriptPubKey for OP_RETURN (+ PUSHDATA)
+        if (cVout.scriptPubKey.hex.startsWith('6a4c')) {
             // Found an OP_RETURN! Parse the message from HEX to UTF-8
             const rawHex = cVout.scriptPubKey.asm.substr(10);
             const buf = Buffer.from(rawHex, 'hex');
@@ -775,7 +775,7 @@ function isNil(a) {
     if (a === undefined || a === null || !a) return true; return false;
 }
 function isEmpty(a) {
-    if (!a.length || isNil(a)) return true; return false;
+    if (isNil(a) || !a.length) return true; return false;
 }
 
 // CORE DAEMON

--- a/src/index.js
+++ b/src/index.js
@@ -501,7 +501,7 @@ async function isCallAuthorized(cTx, strAuthAddr) {
 
 // Chain State Processing
 async function processState(newMsg, tx) {
-    let isLongData = newMsg.length > 64;
+    const isLongData = newMsg.length > 64;
     let isUsingIndex = false;
     if (UPGRADES.isTokenIndexingActive(nCacheHeight)) {
         isUsingIndex = newMsg.startsWith('id');

--- a/src/token.js
+++ b/src/token.js
@@ -434,7 +434,7 @@ function getTokensPtr() {
 
 function getToken(query) {
     // (Indexed ID only!) Fetch a Token by it's Index ID
-    if (typeof query === "number") return stateTokens[query];
+    if (typeof query === 'number') return stateTokens[query];
     // Find a token by it's contract TX-ID
     for (const token of stateTokens) {
         if (token.contract === query) return token;

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -19,7 +19,7 @@
 // - Drops min stake-reward to 1 sat, from 0.001% of max supply.
 // ... allowing more users of smaller balances to participate in
 // ... staking SCP-2 tokens.
-const nUpgradeBlock1_minStake = 9999999; // TODO: Set upgrade block
+const nUpgradeBlock1_minStake = 196000;
 
 // SCP IMPROVEMENT UPGRADE 2
 // - Indexes all SCP Token contracts by their State Index, this

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -12,6 +12,9 @@
     upgrades will take place, this contains all of the smooth-switchover logic.
 */
 
+/* eslint-disable camelcase */
+// Ignore camelcase style warnings
+
 // SCP-2 IMPROVEMENT UPGRADE 1
 // - Drops min stake-reward to 1 sat, from 0.001% of max supply.
 // ... allowing more users of smaller balances to participate in
@@ -33,6 +36,8 @@ function isMinStakeActive(height = Number) {
 function isTokenIndexingActive(height = Number) {
     return height >= nUpgradeBlock2_tokenIndexing;
 }
+
+/* eslint-enable camelcase */
 
 exports.isMinStakeActive = isMinStakeActive;
 exports.isTokenIndexingActive = isTokenIndexingActive;

--- a/src/upgrades.js
+++ b/src/upgrades.js
@@ -1,0 +1,38 @@
+/*
+  # This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+'use strict';
+/*
+    SCP-1 CHAIN-UPGRADE FUNCTIONS
+    -----------------------------
+    This file hosts the constants, params & heights at which SCP & SCC blockchain
+    upgrades will take place, this contains all of the smooth-switchover logic.
+*/
+
+// SCP-2 IMPROVEMENT UPGRADE 1
+// - Drops min stake-reward to 1 sat, from 0.001% of max supply.
+// ... allowing more users of smaller balances to participate in
+// ... staking SCP-2 tokens.
+const nUpgradeBlock1_minStake = 9999999; // TODO: Set upgrade block
+
+// SCP IMPROVEMENT UPGRADE 2
+// - Indexes all SCP Token contracts by their State Index, this
+// ... allows full-nodes to map a 64-byte contract ID to a single
+// ... tiny integer, which enables the network to perform contract
+// ... operations in ~25% less space than before
+// - This upgrade takes place at the same height as the Min Stake upgrade.
+const nUpgradeBlock2_tokenIndexing = nUpgradeBlock1_minStake;
+
+function isMinStakeActive(height = Number) {
+    return height >= nUpgradeBlock1_minStake;
+}
+
+function isTokenIndexingActive(height = Number) {
+    return height >= nUpgradeBlock2_tokenIndexing;
+}
+
+exports.isMinStakeActive = isMinStakeActive;
+exports.isTokenIndexingActive = isTokenIndexingActive;


### PR DESCRIPTION
This PR implements the SCP-2 Staking Improvement Upgrade, this update will allow users with smaller balances to participate in Staking their tokens, by lowering the minimum staking requirement from holding 0.001% of supply, to now simply requiring a minimum stake-reward size of 1 satoshi.

In addition, this includes the SCP Token Indexing upgrade, which will increase TPS by ~25% by allowing the usage of a token's deterministic state index within contract calls, this allows contracts to be called by an integer index, instead of requiring the 64-char TX-ID.

This update is mandatory for all Full-node operators, and has a confirmed hardfork block.