### PR TITLE
[Wallet] [API] Fix listaddresses unlock status

### DIFF
--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -92,11 +92,10 @@ async function listAddresses(req, res) {
     }
     try {
         const arrAddresses = [];
-        const cWalletDB = ptrWALLET.toDB();
-        for (const cAddr of cWalletDB.wallets) {
+        for (const cWallet of ptrWALLET.getWalletsPtr()) {
             arrAddresses.push({
-                'address': cAddr.pubkey,
-                'unlocked': cAddr.privkeyDecrypted.length > 0
+                'address': cWallet.getPubkey(),
+                'unlocked': cWallet.getPrivkey() !== null
             });
         }
         return res.json(arrAddresses);

--- a/src/wallet.js
+++ b/src/wallet.js
@@ -387,6 +387,11 @@ function getUTXOsPtr() {
     return arrUTXOs;
 }
 
+// Returns the direct Wallets cache pointer, NOT recommended for most usage
+function getWalletsPtr() {
+    return arrWallets;
+}
+
 // Lib exports
 exports.sccjs = sccjs;
 // Class
@@ -414,5 +419,6 @@ exports.getIncomingUTXOs = getIncomingUTXOs;
 exports.getAvailableUTXOs = getAvailableUTXOs;
 exports.getCoinsToSpend = getCoinsToSpend;
 exports.getUTXOsPtr = getUTXOsPtr;
+exports.getWalletsPtr = getWalletsPtr;
 exports.countWallets = countWallets;
 exports.toDB = toDB;


### PR DESCRIPTION
The listaddresses unlock checks were previously just checking if addresses had an encrypted copy, but did not care if there was a decrypted copy, now we simply check for decrypted privkeys, and if none is available, the wallet is locked!

This will also perform slightly better due to using less DB-wrapper workarounds, instead using direct pointers.