### PR TITLE
[CSP] [DB] Add Sync Assist feature

### DIFF
--- a/src/database/index.js
+++ b/src/database/index.js
@@ -15,16 +15,19 @@ const path = require('path');
 let appdata;
 let disk;
 let conf;
+let statedb;
 try {
     // GUI
     appdata = require('../src/database/appdata.js');
     disk = require('../src/database/disk.js');
     conf = require('../src/database/config.js');
+    statedb = require('../src/database/state.js');
 } catch(e) {
     // Terminal
     appdata = require('./appdata.js');
     disk = require('./disk.js');
     conf = require('./config.js');
+    statedb = require('./state.js');
 }
 
 // SCC Core data directory
@@ -52,6 +55,16 @@ async function getWallet() {
 // Saves data to the wallet DB
 async function setWallet(data) {
     return await disk.writeSCP('wallet.json', data, true);
+}
+
+// Create a new sync-assist snapshot
+async function createSyncAssistSnap() {
+    return await statedb.setSyncAssist();
+}
+
+// Load the current Sync Assist snapshot, if any exists
+async function getSyncAssistSnap() {
+    return await statedb.getSyncAssist();
 }
 
 // Initialize the DB, config, and paths for SCC & SCP
@@ -105,6 +118,9 @@ async function init(forceCorePath = false, retry = false) {
         }
     }
 
+    // Initialize the StateDB
+    statedb.init(exports, disk);
+
     // Set SCC Core datadir path
     disk.setPath(pathSCC, true);
 
@@ -130,9 +146,12 @@ try {
     exports.join = path.join;
     exports.path = path;
     exports.getConfigValue = conf.getConfigValue;
+    exports.state = statedb;
     // Funcs
     exports.appdata = appdata;
     exports.getWallet = getWallet;
     exports.setWallet = setWallet;
+    exports.createSyncAssistSnap = createSyncAssistSnap;
+    exports.getSyncAssistSnap = getSyncAssistSnap;
     exports.init = init;
 } catch(e) {}

--- a/src/database/state.js
+++ b/src/database/state.js
@@ -1,0 +1,51 @@
+/*
+  # This Source Code Form is subject to the terms of the Mozilla Public
+  # License, v. 2.0. If a copy of the MPL was not distributed with this
+  # file, You can obtain one at https://mozilla.org/MPL/2.0/.
+*/
+
+'use strict';
+/*
+    STATE DATABASE FUNCTIONS
+    ------------------------
+    This file hosts the database functionality of the SCP State,
+    allowing the ability to save the state to disk, read the state,
+    or create 'sync assist' snapshots for assisted full-node syncs.
+*/
+
+// Modules
+let DB, disk;
+
+// Pointers
+let arrStatePtr = [];
+
+function init(context, d) {
+    DB = context;
+    disk = d;
+}
+
+function setStateMsgPtr(ptr) {
+    arrStatePtr = ptr;
+}
+
+async function setSyncAssist() {
+    // Create a non-duplicate, height-only map of all state message blocks
+    const arrBlks = Array.from(new Set(arrStatePtr.map(a => a.height)));
+    // Save to disk as JSON
+    return await disk.writeSCP('snap.sync', arrBlks, true);
+}
+
+async function getSyncAssist() {
+    // Open the Sync Assist file, if any exists
+    const arrBlks = await disk.readSCP('snap.sync', true);
+    // Always keep ascending order
+    if (Array.isArray(arrBlks)) {
+        arrBlks.sort((a, b) => { return a - b });
+    }
+    return arrBlks;
+}
+
+exports.init = init;
+exports.setStateMsgPtr = setStateMsgPtr;
+exports.setSyncAssist = setSyncAssist;
+exports.getSyncAssist = getSyncAssist;


### PR DESCRIPTION
# Why?
To prepare for the growth of the SCP network and allow our nodes to quickly scale'n'bootstrap, we've developed the Sync Assist feature; this feature allows Full-nodes to create, export, import and utilize Sync Assist "snap.sync" files to leverage a massive boost in syncing speed by removing the unnecessary scanning of empty and/or non-SCP blocks.

# How?
The "snap.sync" file contains an index of block heights at which SCP transactions have occurred, this speeds up the syncing process by aid of a precomputed index, this file is also extremely secure, even if tampered, as nodes using Sync Assist must still fully validate all blocks within the file, the state cannot be forcefully edited by manipulating and/or distributing tampered Sync Assist files.

# When?
Sync Assist is automatically enabled on all nodes, it will produce it's own files only when fully synchronized, and utilize them for faster restarts in the future, this file can also be safely shared online with friends or strangers alike, to speed up their own node syncs.