### PR TITLE
[SCP-2] Improve PoS performance w/ object reuse

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -511,7 +511,7 @@
 
                       case 'redeem':
                           cActivity.type = 'staked';
-                          const cStatus = isFullnode ? cToken.getStakingStatus(cAccount) :
+                          const cStatus = isFullnode ? cToken.getStakingStatus(cToken.getAccount(cAccount)) :
                                                        JSON.parse(await NET.getLightStakingStatus(cToken.contract, cAccount));
                           cActivity.amount = cStatus.unclaimed_rewards;
                           if (!account ||
@@ -1387,7 +1387,7 @@
       if (isFullnode) {
         guiStakingToken   = TOKENS.getToken(contract);
         guiStakingAccount = guiStakingToken.getAccount(strPubkey);
-        guiStakingStatus  = guiStakingToken.getStakingStatus(strPubkey);
+        guiStakingStatus  = guiStakingToken.getStakingStatus(guiStakingAccount);
       } else {
         guiStakingToken   = getCachedToken(contract);
         guiStakingAccount = getCachedAccount(guiStakingToken);

--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -306,7 +306,7 @@ async function getMempoolActivity(req, res) {
 
                         case 'redeem':
                             cActivity.type = 'staked';
-                            const cStatus = cToken.getStakingStatus(cAccount);
+                            const cStatus = cToken.getStakingStatus(cToken.getAccount(cAccount));
                             cActivity.amount = cStatus.unclaimed_rewards;
                             if (!account ||
                                     (account && cAccount === account)) {

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -101,7 +101,7 @@ async function getStakingStatus(req, res) {
             'error': 'Token is not an SCP-2!'
         });
     }
-    res.json(cToken.getStakingStatus(req.params.account));
+    res.json(cToken.getStakingStatus(cToken.getAccount(req.params.account)));
 }
 
 /* ---- NFTs (SCP-4) ---- */

--- a/src/index.js
+++ b/src/index.js
@@ -902,7 +902,7 @@ async function processState(newMsg, tx) {
                     const fSafe = await isCallAuthorized(tx, addrCaller);
                     if (fSafe) {
                         // Authentication successful, redeeming tokens!
-                        cToken.redeemRewards(addrCaller, tx);
+                        cToken.redeemRewards(cToken.getAccount(addrCaller), tx);
                     } else {
                         console.error('An attempt to redeem SCP-' +
                                       cToken.version + ' stakes containing ' +


### PR DESCRIPTION
After some investigation, the PoS protocol of SCP-2 was found to be slowing down quite drastically as more users began staking, this was due to excessive re-initialization of Token Account variables through most of the PoS related functions.

Through minimizing string-searches and caching account pointers, the sync has been dropped from roughly ~9m 20s to ~1m 50s, an approximate 380% (3.8x) increase in syncing speed!