### PR TITLE
[API] [SCP] Add new API security + cache system

### DIFF
--- a/docs/misc/scp-configurations-file.md
+++ b/docs/misc/scp-configurations-file.md
@@ -12,3 +12,4 @@ The configuration file is automatically created in the users home directory of t
 | coreconfname | stakecubecoin.conf | Name of the SCC Core Node configuration file | scc.conf |
 | apimodules | none | Comma-seperated list of exposed REST API modules | `activity`, `blockchain`, `tokens`, `wallet`, `io` |
 | apiport | 3000 | The port the REST API listens | 3001 |
+| allowedips | 127.0.0.1 (localhost) | The IPs that the API is exposed to | `127.0.0.1`, `123.123.123.123`, `all` |

--- a/public/index.html
+++ b/public/index.html
@@ -759,8 +759,6 @@
       let strRendering = '';
       // Check if we're rendering all our NFTs, or a specific contract's NFTs
       if (nContract === -1) {
-        const strAddr = WALLET.getActiveWallet().getPubkey();
-        getMempoolActivity(strAddr, true);
         // Set title
         domCollectionsName.innerText = 'My NFTs';
         // Hide the mint button
@@ -1575,20 +1573,17 @@
       const strAddr = WALLET.getActiveWallet().getPubkey();
       if (strAddr) {
         getUnspentTransactions();
-        if (isFullnodePtr()) {
-          // Fetches all activity via fullnode
-          getMempoolActivity(strAddr).then(arrRes => cachedActivityIS = arrRes);
-        } else {
+        if (!isFullnodePtr()) {
           // Fetches SCP-1 and SCP-2 activity
           NET.getMempoolActivityLight(strAddr).then(strRes => {
             cachedActivityIS = JSON.parse(strRes);
           });
           // Updates NFTs and other contracts
-          getMempoolActivity(strAddr).then(res => {
-            if (domViewNFT.style.display === "block") {
+          if (domViewNFT.style.display === "block") {
+            getMempoolActivity(strAddr).then(res => {
               renderDetailedNFT(domNftDetailID.innerText);
-            }
-          });
+            });
+          }
         }
       }
       // Update Dashboard stats

--- a/src/api/activity.controller.js
+++ b/src/api/activity.controller.js
@@ -284,7 +284,8 @@ async function getMempoolActivity(req, res) {
 
                         case 'redeem':
                             cActivity.type = 'staked';
-                            const cStatus = cToken.getStakingStatus(cToken.getAccount(cAccount));
+                            const cStatus = cToken.getStakingStatus(cToken
+                                .getAccount(cAccount));
                             cActivity.amount = cStatus.unclaimed_rewards;
                             if (!account ||
                                     (account && cAccount === account)) {
@@ -336,8 +337,9 @@ function disabledError(res) {
 function hasPermission(req, res) {
     // Caller IP check
     if (!arrAllowedCallers.includes('all') &&
-        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
-            return callerError(req, res);
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, ''))) {
+        return callerError(req, res);
+    }
     // Full Node check
     if (!ptrIsFullnode()) return fullnodeError(res);
     // Module activation status

--- a/src/api/blockchain.controller.js
+++ b/src/api/blockchain.controller.js
@@ -55,8 +55,9 @@ function disabledError(res) {
 function hasPermission(req, res) {
     // Caller IP check
     if (!arrAllowedCallers.includes('all') &&
-        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
-            return callerError(req, res);
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, ''))) {
+        return callerError(req, res);
+    }
     // Full Node check
     if (!ptrIsFullnode()) return fullnodeError(res);
     // Module activation status

--- a/src/api/io.controller.js
+++ b/src/api/io.controller.js
@@ -52,7 +52,7 @@ async function readTx(req, res) {
             'error': 'Encoding format (' + strFormat + ') is invalid'
         });
     }
-    res.json(await ptrGetMsgFromTx(strTxid, strFormat));
+    res.json(await ptrGetMsgFromTx(strTxid, true, strFormat));
 }
 
 async function writeTx(req, res) {

--- a/src/api/io.controller.js
+++ b/src/api/io.controller.js
@@ -410,8 +410,9 @@ function disabledError(res) {
 function hasPermission(req, res) {
     // Caller IP check
     if (!arrAllowedCallers.includes('all') &&
-        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
-            return callerError(req, res);
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, ''))) {
+        return callerError(req, res);
+    }
     // Full Node check
     if (!ptrIsFullnode()) return fullnodeError(res);
     // Module activation status

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -14,11 +14,13 @@ let ptrTOKENS;
 let ptrNFT;
 let ptrIsFullnode;
 let strModule;
+let arrAllowedCallers;
 
 function init(context) {
     ptrTOKENS = context.TOKENS;
     ptrNFT = context.NFT;
     ptrIsFullnode = context.isFullnode;
+    arrAllowedCallers = context.callers;
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     // Initialize permissions controller
@@ -28,22 +30,13 @@ function init(context) {
 /* ---- Divisible Tokens (SCP-1, SCP-2) ---- */
 
 async function getAllTokens(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
     res.json(ptrTOKENS.getTokensPtr());
 }
 
 function getToken(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.contract || req.params.contract.length !== 64) {
         return res.json({
             'error': "You must specify a 'contract' param!"
@@ -59,12 +52,8 @@ function getToken(req, res) {
 }
 
 function getTokensByAccount(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.account || req.params.account.length <= 1) {
         return res.json({
             'error': "You must specify an 'account' param!"
@@ -74,12 +63,8 @@ function getTokensByAccount(req, res) {
 }
 
 async function getStakingStatus(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.contract || req.params.contract.length !== 64) {
         return res.json({
             'error': "You must specify a 'contract' param!"
@@ -107,32 +92,18 @@ async function getStakingStatus(req, res) {
 /* ---- NFTs (SCP-4) ---- */
 
 async function getAllCollections(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
     res.json(ptrNFT.getCollectionPtr());
 }
 
 async function getAllCollectionHeaders(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
     res.json(ptrNFT.getAllCollectionHeaders());
 }
 
 function getCollection(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.contract) {
         return res.json({
             'error': "You must specify a 'contract' param!"
@@ -148,12 +119,8 @@ function getCollection(req, res) {
 }
 
 function getNFTsByAccount(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.account || req.params.account.length <= 1) {
         return res.json({
             'error': "You must specify an 'account' param!"
@@ -163,12 +130,8 @@ function getNFTsByAccount(req, res) {
 }
 
 function getNFTbyID(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.id || req.params.id.length <= 1) {
         return res.json({
             'error': "You must specify an 'id' param!"
@@ -177,17 +140,40 @@ function getNFTbyID(req, res) {
     res.json(ptrNFT.getNFTbyId(req.params.id));
 }
 
+function callerError(req, res) {
+    res.status(403).json({
+        'error': 'Your IP (' + req.ip + ') is not in the API whitelist!'
+    });
+    return false;
+}
+
 function fullnodeError(res) {
-    return res.status(403).json({
+    res.status(403).json({
         'error': 'This endpoint is only available to Full-nodes, please ' +
                  'connect an SCC Core RPC server to enable as a Full-node!'
     });
+    return false;
 }
 
 function disabledError(res) {
-    return res.status(403).json({
+    res.status(403).json({
         'error': 'This module (' + strModule + ') is disabled!'
     });
+    return false;
+}
+
+function hasPermission(req, res) {
+    // Caller IP check
+    if (!arrAllowedCallers.includes('all') &&
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
+            return callerError(req, res);
+    // Full Node check
+    if (!ptrIsFullnode()) return fullnodeError(res);
+    // Module activation status
+    if (!cPerms.isModuleAllowed(strModule)) return disabledError(res);
+
+    // If we reach here, then all checks are a-go!
+    return true;
 }
 
 exports.init = init;

--- a/src/api/tokens.controller.js
+++ b/src/api/tokens.controller.js
@@ -165,8 +165,9 @@ function disabledError(res) {
 function hasPermission(req, res) {
     // Caller IP check
     if (!arrAllowedCallers.includes('all') &&
-        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
-            return callerError(req, res);
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, ''))) {
+        return callerError(req, res);
+    }
     // Full Node check
     if (!ptrIsFullnode()) return fullnodeError(res);
     // Module activation status

--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -19,6 +19,7 @@ let strModule;
 let COIN;
 let nDeployFee;
 let strDeployFeeDest;
+let arrAllowedCallers;
 
 function init(context) {
     ptrWALLET = context.WALLET;
@@ -26,6 +27,7 @@ function init(context) {
     ptrDB = context.DB;
     ptrNFT = context.NFT;
     ptrIsFullnode = context.isFullnode;
+    arrAllowedCallers = context.callers;
     // Static Non-Pointer (native value)
     strModule = context.strModule;
     COIN = context.COIN;
@@ -36,12 +38,8 @@ function init(context) {
 }
 
 async function getBalances(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.account || req.params.account.length !== 34) {
         return res.status(400).send('Missing "account" parameter!');
     }
@@ -90,12 +88,8 @@ async function getBalances(req, res) {
 }
 
 async function listAddresses(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     try {
         const arrAddresses = [];
         for (const cWallet of ptrWALLET.getWalletsPtr()) {
@@ -113,12 +107,8 @@ async function listAddresses(req, res) {
 }
 
 async function getNewAddress(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     try {
         // Create a new wallet address
         const cWallet = await ptrWALLET.createWallet();
@@ -133,12 +123,8 @@ async function getNewAddress(req, res) {
 }
 
 async function send(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -293,12 +279,8 @@ async function send(req, res) {
 }
 
 async function stake(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -377,12 +359,8 @@ async function stake(req, res) {
 }
 
 async function createCollection(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -478,12 +456,8 @@ async function createCollection(req, res) {
 }
 
 async function mintNFT(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -566,12 +540,8 @@ async function mintNFT(req, res) {
 }
 
 async function burnNFT(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -660,12 +630,8 @@ async function burnNFT(req, res) {
 }
 
 async function transferNFT(req, res) {
-    if (!cPerms.isModuleAllowed(strModule)) {
-        return disabledError(res);
-    }
-    if (!ptrIsFullnode()) {
-        return fullnodeError(res);
-    }
+    if (!hasPermission(req, res)) return false;
+
     if (!req.params.address || req.params.address.length !== 34) {
         return res.status(400).send('Missing "address" parameter!');
     }
@@ -751,17 +717,40 @@ async function transferNFT(req, res) {
     }
 }
 
+function callerError(req, res) {
+    res.status(403).json({
+        'error': 'Your IP (' + req.ip + ') is not in the API whitelist!'
+    });
+    return false;
+}
+
 function fullnodeError(res) {
-    return res.status(403).json({
+    res.status(403).json({
         'error': 'This endpoint is only available to Full-nodes, please ' +
                  'connect an SCC Core RPC server to enable as a Full-node!'
     });
+    return false;
 }
 
 function disabledError(res) {
-    return res.status(403).json({
+    res.status(403).json({
         'error': 'This module (' + strModule + ') is disabled!'
     });
+    return false;
+}
+
+function hasPermission(req, res) {
+    // Caller IP check
+    if (!arrAllowedCallers.includes('all') &&
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
+            return callerError(req, res);
+    // Full Node check
+    if (!ptrIsFullnode()) return fullnodeError(res);
+    // Module activation status
+    if (!cPerms.isModuleAllowed(strModule)) return disabledError(res);
+
+    // If we reach here, then all checks are a-go!
+    return true;
 }
 
 exports.init = init;

--- a/src/api/wallet.controller.js
+++ b/src/api/wallet.controller.js
@@ -742,8 +742,9 @@ function disabledError(res) {
 function hasPermission(req, res) {
     // Caller IP check
     if (!arrAllowedCallers.includes('all') &&
-        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, '')))
-            return callerError(req, res);
+        !arrAllowedCallers.includes(req.ip.replace(/::ffff:/g, ''))) {
+        return callerError(req, res);
+    }
     // Full Node check
     if (!ptrIsFullnode()) return fullnodeError(res);
     // Module activation status

--- a/src/index.js
+++ b/src/index.js
@@ -164,10 +164,10 @@ async function init(forcedCorePath = false, retry = false) {
         NFT.init(getBlockcount);
         // Load which caller addresses (if any) can call the API
         const arrAllowedCallers = DB.getConfigValue('allowedips', '127.0.0.1',
-                                                    false)
-                                                    .replace(/::ffff:/g, '')
-                                                    .replace(/ /g, '')
-                                                    .split(',');
+            false)
+            .replace(/::ffff:/g, '')
+            .replace(/ /g, '')
+            .split(',');
         // Initialize API modules, providing mutable pointer contexts to all necessary states
         if (!fInitialized) {
             fInitialized = true;
@@ -496,8 +496,9 @@ async function getMsgsFromBlock(blk) {
 async function getMsgFromTx(rawTX, useCache = false, strFormat = 'utf8') {
     let res;
     try {
-        res = await (useCache ? getRawTx(rawTX) :
-                                rpcMain.call('getrawtransaction', rawTX, 1));
+        res = await (useCache
+            ? getRawTx(rawTX)
+            : rpcMain.call('getrawtransaction', rawTX, 1));
     } catch(e) {
         return {
             'error': true,
@@ -538,8 +539,9 @@ async function getRawTx(strID) {
     // TX not cached, fetch it the long way and cache it!
     const cTx = await rpcMain.call('getrawtransaction', strID, 1);
     // Only cache TXs that are InstantLock'd, for security
-    if (cTx.instantlock || cTx.chainlock)
+    if (cTx.instantlock || cTx.chainlock) {
         arrRawTxCache.unshift(cTx);
+    }
     // Ensure the cache doesn't grow "too" big
     if (arrRawTxCache.length > 10000) arrRawTxCache.pop();
     // Return the cached result


### PR DESCRIPTION
## 🔐 A new config setting `"allowedips"` is now available
This adds a security setting which acts as a whitelisting system for IPs, essentially a simple built-in firewall system.

This setting supports either a single string, or a list of comma-seperated strings, each of the strings must be one of these options:
`"all"` - Exposes the API to all IPs.
`"<ip-address>"` - A valid IP address to be whitelisted for system access.

To have a localhost-only accessible API, which is considered the "hardened" client, do not add the setting to your config, it will automatically use localhost only mode when the setting is missing!

**Some example usecases:**
- A local exchange hot-wallet would leave the option as default, which is localhost (127.0.0.1) only.

- A networked exchange wallet, where the exchange and wallet are on separate servers, would add the exchange server's IP
(or proxy IP) into the wallet's config, this means the API can only be accessed by the exchange's host and/or proxy.

- An explorer and/or public API would use the "all" setting, which allows any IP to access the exposed API modules without prior whitelisting, including localhost.

## ⚡ A new minimal TX cache system
To speed-up some parts of SCP, as well as lessen the pressure on the API <---> RPC, a new raw TX cache system has been added which will automatically cache IS/CL-lock'd TXs used in previous calls, and re-use them when necessary, non-critical components of SCP are now using this, such as contract authorization and the `io/read` endpoint.