### PR TITLE
Fix .deb builds for SCP

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "config": {
     "forge": {
       "packagerConfig": {
+        "name": "stakecubeprotocol",
         "icon": "./public/imgs/scp",
         "ignore": ["docs", ".github", ".gitignore", "linter.js", ".eslintrc.js"]
       },


### PR DESCRIPTION
Since my attempts to build Linux, it was building deb and rpm.
Which would produce errors as, 

 ```
 Making for the following targets: deb, rpm

✖ Making for target: deb - On platform: linux - For arch: x64

An unhandled error has occurred inside Forge:
An error occured while making for target: deb
could not find the Electron app binary at "/root/scc/out/SCP Wallet-linux-x64/stakecubeprotocol". You may need to re-bundle the app using Electron Packager's "executableName" option.
Error: could not find the Electron app binary at "/root/scc/out/SCP Wallet-linux-x64/stakecubeprotocol". You may need to re-bundle the app using Electron Packager's "executableName" option.
    at error.wrapError (/root/scc/node_modules/electron-installer-common/src/installer.js:154:15)
```

Build Steps-
- apt-get install -y npm && rpm 
- apt-get install git -y
- git clone https://github.com/stakecube/StakeCubeProtocol.git scc
- cd scc
- npm i
- (if this does not install everything)
- npm install -g electron-forge
- npm install -g electron-installer-debian
- (then build)
- npm run-script make

This update resolves the .deb compilation error and allows both to be produced.
